### PR TITLE
Fix indentation error causing syntax error

### DIFF
--- a/download.py
+++ b/download.py
@@ -369,8 +369,8 @@ def download_youtube_content(urls: List[str], output_path: Optional[str] = None,
     if failed_downloads:
         print("\n❌ Failed URLs:")
         for result in failed_downloads:
-        print(f"   • {result['url']}")
-        print(f"     Reason: {result['message']}")
+            print(f"   • {result['url']}")
+            print(f"     Reason: {result['message']}")
 
     if successful_downloads:
         print(f"\n🎉 All files saved to: {output_path}")


### PR DESCRIPTION
## Fix indentation error at line 371

### Problem
When running the script, Python raises an `IndentationError` at lines 371:
```
IndentationError: expected an indented block after 'for' statement on line 371
```

### Solution
Fixed incorrect indentation in the `[download_youtube_content]` function. The lines 372 and 373 were lacking a tab before print statements, which caused the interpreter to fail.

### Testing
- Ran the script with Python 3.12.4
- Confirmed no indentation errors occur
- Verified functionality works as expected