### PR TITLE
Skip unavailable entries in playlists/channels instead of aborting the whole download

### DIFF
--- a/download.py
+++ b/download.py
@@ -230,11 +230,15 @@ def download_single_video(
 
         archive_name = '.video_download_archive'
 
+    content_type, _ = get_url_info(url)
+
     downloader_options = {
         'format': format_selector,
 
-        # Do not silently ignore failures
-        'ignoreerrors': False,
+        # For playlists/channels, skip unavailable entries (e.g. removed
+        # videos) instead of aborting the whole batch. Single videos still
+        # fail loudly since there's nothing else to continue past.
+        'ignoreerrors': 'only_download' if content_type in ('playlist', 'channel') else False,
 
         'no_warnings': False,
         'noplaylist': False,
@@ -270,8 +274,6 @@ def download_single_video(
 
     if not audio_only:
         downloader_options['merge_output_format'] = 'mp4'
-
-    content_type, _ = get_url_info(url)
 
     if content_type == 'playlist':
         downloader_options['outtmpl'] = os.path.join(
@@ -359,6 +361,8 @@ def download_single_video(
                         if entry is not None
                     )
 
+                    skipped_count = len(entries) - video_count
+
                     if video_count == 0:
                         raise Exception(
                             "Playlist appears empty or unavailable"
@@ -367,7 +371,8 @@ def download_single_video(
                     print(
                         f"📋 [Thread {thread_id}] "
                         f"{content_type.title()}: "
-                        f"'{title}' ({video_count} videos)"
+                        f"'{title}' ({video_count} videos"
+                        f"{f', {skipped_count} skipped' if skipped_count else ''})"
                     )
 
                     return {
@@ -379,7 +384,8 @@ def download_single_video(
                             f"{content_type.title()} "
                             f"'{title}' download completed! "
                             f"({video_count} "
-                            f"{'MP3s' if audio_only else 'videos'}) "
+                            f"{'MP3s' if audio_only else 'videos'}"
+                            f"{f', {skipped_count} unavailable/skipped' if skipped_count else ''}) "
                             f"📂 Location: {output_path}"
                         )
                     }

--- a/test_download.py
+++ b/test_download.py
@@ -11,9 +11,11 @@ import os
 import subprocess
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from yt_dlp import YoutubeDL
 
+import download
 from download import (
     download_single_video,
 )
@@ -180,6 +182,55 @@ class TestFormatSelectionWithLimit(unittest.TestCase):
             height, self.max_res,
             msg=f"Video stream height is {height}p — expected at most {self.max_res}p.",
         )
+
+
+# ---------------------------------------------------------------------------
+# Test: ignoreerrors is scoped correctly by content type (no network)
+# ---------------------------------------------------------------------------
+
+class _FakeYoutubeDL:
+    """Records the opts it was constructed with; never touches the network."""
+
+    captured_opts = None
+
+    def __init__(self, opts):
+        _FakeYoutubeDL.captured_opts = opts
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def extract_info(self, url, download=True):
+        return {'_type': 'video', 'title': 'Fake Video', 'id': 'abc123'}
+
+
+class TestIgnoreErrorsByContentType(unittest.TestCase):
+    """
+    A single unavailable video must not abort an entire playlist/channel
+    download, but a lone video should still fail loudly. ignoreerrors
+    controls this, and must be set per content type.
+    """
+
+    def _captured_ignoreerrors(self, content_type):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch.object(download, 'YoutubeDL', _FakeYoutubeDL), \
+                 patch.object(download, 'get_url_info', return_value=(content_type, {})):
+                download_single_video(
+                    url="https://www.youtube.com/watch?v=abc123",
+                    output_path=tmp_dir,
+                )
+        return _FakeYoutubeDL.captured_opts['ignoreerrors']
+
+    def test_playlist_skips_unavailable_entries(self):
+        self.assertEqual(self._captured_ignoreerrors('playlist'), 'only_download')
+
+    def test_channel_skips_unavailable_entries(self):
+        self.assertEqual(self._captured_ignoreerrors('channel'), 'only_download')
+
+    def test_single_video_fails_loudly(self):
+        self.assertFalse(self._captured_ignoreerrors('video'))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #24

## Problem

Downloading a playlist stopped entirely the moment it hit a single removed/unavailable video, even when most of the playlist was downloadable. This is because `ignoreerrors` was hardcoded to `False` for every content type, so `ydl.extract_info()` raised on the first unavailable entry and aborted the batch — every video after it in the playlist never got attempted.

## Fix

- Moved the `content_type` lookup (`get_url_info()`) earlier in `download_single_video()`, before `downloader_options` is built.
- Set `ignoreerrors` conditionally: `'only_download'` for `playlist`/`channel` (skip unavailable entries, keep going), `False` for a lone `video` (still fail loudly there, since there's nothing else in the batch to continue past).
- Added a `skipped_count` to the playlist result — both the console progress line and the final summary message now show how many entries were skipped, so a partially-completed playlist doesn't look identical to a fully-completed one.

## Testing

Verified locally against a real 52-video playlist containing 3 videos removed by YouTube for ToS violations (not at the end of the list):
- **Before the fix**: download aborted at the first removed video; nothing after it in the playlist was attempted.
- **After the fix**: the 3 removed videos were skipped and reported, and the rest of the playlist (previously-unreached videos) downloaded successfully.

## Test plan
- [x] Ran against a real playlist with unavailable entries in the middle of the list; confirmed the run now completes and skipped entries are reported
- [ ] Maintainer review of the `ignoreerrors` value choice (`'only_download'` vs `True`) for edge cases with postprocessors